### PR TITLE
Tell IRenderer about WindowEventType::Resized events

### DIFF
--- a/engine/core/source/Core/Engine.cpp
+++ b/engine/core/source/Core/Engine.cpp
@@ -117,7 +117,18 @@ namespace chai
             FrameMarkStart("Engine");
 
             input->newFrame();  //tell input to clear deltas FIRST
-            window->pollEvents();
+
+            std::span<const WindowEvent> events{ window->pollEvents() };
+
+            for (const WindowEvent& event : events) {
+
+                // tell the renderer about resized events
+                if (event.type == WindowEventType::Resized)
+                    renderer->onResize(event.width, event.height);
+
+            }
+
+
             renderer->startFrame();
             float dt = clock_.tick();
 


### PR DESCRIPTION
This MR adds a loop over `WindowEvent` events and calls `IRenderer::onResize(...)` when `type` is `WindowEventType::Resized`. This fixes a window resizing issue found on Ubuntu.